### PR TITLE
ci: pin codeql-action init and analyze to the same version (v4.37.8)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: { persist-credentials: false }
-      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a #v4.37.1
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 #v4.37.8
         with:
           languages: javascript-typescript
           queries: security-extended # broader security query suite than the default
@@ -34,4 +34,4 @@ jobs:
             paths-ignore:
               - playground/cairn-engine.js
               - playground/lib
-      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a #v4.37.1
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 #v4.37.8


### PR DESCRIPTION
## Problem

The `analyze` job fails on every PR:

```
Error: Loaded a configuration file for version '4.37.1', but running version '4.37.8'
```

`codeql-action/init` writes a config file stamped with its own action version. `codeql-action/analyze` reads that file and refuses to run when the stamp does not match its own version. The two steps must always be pinned to the same version.

Dependabot treats `github/codeql-action/init` and `github/codeql-action/analyze` as separate dependencies, because they are distinct `uses:` paths. It therefore opens one PR per step, and each of those bumps only half of the pair:

| PR | init | analyze | result |
| --- | --- | --- | --- |
| #65 | `7188fc36` v4.37.1 | `db488dde` **v4.37.8** | mismatch, `analyze` fails |
| #66 | `ff2f1c62` **v4.37.7** | `7188fc36` v4.37.1 | mismatch, `analyze` fails |

Neither can go green on its own, and merging both would leave `main` at init 4.37.7 vs analyze 4.37.8 — the same failure, on the default branch.

## Change

Move both pins to v4.37.8 in one commit. `init` and `analyze` ship from the same repository, so they share a commit SHA: `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28` is the v4.37.8 tag (verified against the GitHub API). The identical SHA on both lines is intentional, not a copy-paste error.

## Follow-up

This will recur on every codeql-action release. A `groups:` entry in `.github/dependabot.yml` covering `github/codeql-action/*` would make Dependabot bump both steps in a single PR. Not included here to keep this change minimal.

Supersedes #65 and #66 — both can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hMtj6QbceDoKHee4oRMqX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code security scanning to the latest CodeQL action version.
  * No changes were made to workflow behavior or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->