### PR TITLE
Add the possibility to zoom, unzoom and drag the diagram in the playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,17 @@ Architecture views get wide, so the preview pane pans and zooms:
 | Zoom in / out | The `−` and `+` buttons, or the `-` and `+` keys |
 | Zoom at the pointer | `ctrl`/`⌘` + mouse wheel, or a trackpad pinch |
 | Back to 100% | Click the percentage readout, or press `0` |
-| Fit the whole diagram | The `fit` button |
+| Shrink an oversized diagram to fit | The `fit` button |
 | Pan | Drag the diagram, or use the pane's scrollbars |
 
-The zoom level and the panned position both survive a re-render, so editing the
-source does not throw away the spot you were looking at.
+A diagram that arrives whole — pasted over the editor's contents, picked from
+the templates menu, or opened from a share link — is fitted to the pane
+automatically, so a wide view lands on screen in one piece. `fit` only ever
+shrinks; it will not magnify a small diagram to fill the pane.
+
+While you edit, the zoom level and the panned position both survive a
+re-render, so changing the source does not throw away the spot you were
+looking at.
 
 ## Preview
 

--- a/README.md
+++ b/README.md
@@ -66,27 +66,6 @@ As a result here's a comparaison of the same diagram done with D2 (ELK Layout) v
 
 Either use the cli or the [ playground](https://cairn-psi-five.vercel.app/).
 
-### Reading a diagram in the playground
-
-Architecture views get wide, so the preview pane pans and zooms:
-
-| Action | How |
-|---|---|
-| Zoom in / out | The `−` and `+` buttons, or the `-` and `+` keys |
-| Zoom at the pointer | `ctrl`/`⌘` + mouse wheel, or a trackpad pinch |
-| Back to 100% | Click the percentage readout, or press `0` |
-| Shrink an oversized diagram to fit | The `fit` button |
-| Pan | Drag the diagram, or use the pane's scrollbars |
-
-A diagram that arrives whole — pasted over the editor's contents, picked from
-the templates menu, or opened from a share link — is fitted to the pane
-automatically, so a wide view lands on screen in one piece. `fit` only ever
-shrinks; it will not magnify a small diagram to fill the pane.
-
-While you edit, the zoom level and the panned position both survive a
-re-render, so changing the source does not throw away the spot you were
-looking at.
-
 ## Preview
 
 Every image below is rendered by cairn CLI from a `.cairn` source in [`examples/`](examples/) — plain SVG, zero label overlaps.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ As a result here's a comparaison of the same diagram done with D2 (ELK Layout) v
 
 Either use the cli or the [ playground](https://cairn-psi-five.vercel.app/).
 
+### Reading a diagram in the playground
+
+Architecture views get wide, so the preview pane pans and zooms:
+
+| Action | How |
+|---|---|
+| Zoom in / out | The `−` and `+` buttons, or the `-` and `+` keys |
+| Zoom at the pointer | `ctrl`/`⌘` + mouse wheel, or a trackpad pinch |
+| Back to 100% | Click the percentage readout, or press `0` |
+| Fit the whole diagram | The `fit` button |
+| Pan | Drag the diagram, or use the pane's scrollbars |
+
+The zoom level and the panned position both survive a re-render, so editing the
+source does not throw away the spot you were looking at.
+
 ## Preview
 
 Every image below is rendered by cairn CLI from a `.cairn` source in [`examples/`](examples/) — plain SVG, zero label overlaps.

--- a/playground/index.html
+++ b/playground/index.html
@@ -24,8 +24,12 @@
   .diag .help { color:var(--dim); display:block; }
   a.note { color:var(--dim); text-decoration:underline; }
   .right { flex:1; display:flex; flex-direction:column; min-width:0; }
-  #preview { flex:1; overflow:auto; background:#ffffff; display:flex; align-items:flex-start; position:relative; }
-  #preview svg { max-width:none; }
+  #preview { flex:1; overflow:auto; background:#ffffff; display:flex; align-items:flex-start; position:relative; cursor:grab; }
+  #preview.panning { cursor:grabbing; }
+  #preview.error { cursor:default; }
+  /* flex:none — a zoomed-in diagram is wider than the pane, and the default
+     flex-shrink would squeeze it back to fit instead of letting it overflow. */
+  #preview svg { max-width:none; flex:none; }
   #preview.stale svg { opacity:.45; transition:opacity .1s; }
   #preview.error { background:#fff5f5; }
   .err-panel { margin:auto; max-width:460px; padding:32px; text-align:center; }
@@ -34,8 +38,11 @@
   .err-panel .err-p { margin-top:8px; font-size:13.5px; line-height:1.6; color:#8a5a5a; }
   #status { padding:6px 14px; background:var(--panel); border-top:1px solid var(--border); font-size:12px; color:var(--dim); display:flex; gap:16px; align-items:center; }
   #status .ok { color:var(--ok); } #status .err { color:var(--err); }
-  #zoom { margin-left:auto; display:flex; gap:6px; }
+  #zoom { margin-left:auto; display:flex; gap:6px; align-items:center; }
   #zoom button { background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:4px; width:26px; cursor:pointer; }
+  #zoom button:hover { border-color:var(--accent); }
+  #zoom-level { width:52px; font-variant-numeric:tabular-nums; }
+  #zoom-fit { width:auto; padding:0 8px; }
   .note { color:var(--dim); font-size:12px; }
 </style>
 </head>
@@ -74,9 +81,14 @@
     <div id="diags"></div>
   </div>
   <div class="right">
-    <div id="preview"></div>
+    <div id="preview" title="Drag to pan · ctrl/⌘ + wheel to zoom"></div>
     <div id="status"><span id="stat">loading engine…</span>
-      <span id="zoom"><button data-z="0.75">−</button><button data-z="1">1×</button><button data-z="1.333">+</button></span>
+      <span id="zoom">
+        <button data-zoom="out" title="Zoom out (−)">−</button>
+        <button data-zoom="reset" id="zoom-level" title="Reset to 100% (0)">100%</button>
+        <button data-zoom="in" title="Zoom in (+)">+</button>
+        <button data-zoom="fit" id="zoom-fit" title="Fit the whole diagram in the pane">fit</button>
+      </span>
     </div>
   </div>
 </main>
@@ -135,6 +147,7 @@ const diagsEl = document.getElementById('diags');
 const stat    = document.getElementById('stat');
 const note    = document.getElementById('note');
 const themeSel = document.getElementById('theme');
+const zoomLevel = document.getElementById('zoom-level');
 let lastSvg = null, lastMatrix = null, zoom = 1, currentTheme = '';
 
 // Populate the theme dropdown from the engine's theme list.
@@ -179,11 +192,15 @@ async function run() {
     if (r.svg) {
       lastSvg = r.svg;
       preview.classList.remove('error');
+      // Replacing the SVG resets the pane's scroll, which would throw away the
+      // reader's pan on every keystroke. Put it back after the new one is sized.
+      const { scrollLeft, scrollTop } = preview;
       preview.innerHTML = r.svg;
       // match the preview backdrop to the theme's canvas colour
       const bg = (r.svg.match(/<rect width="\d+" height="\d+" fill="([^"]+)"\/>/) || [])[1];
       if (bg) preview.style.background = bg;
       applyZoom();
+      preview.scrollTo(scrollLeft, scrollTop);
       stat.innerHTML = `<span class="ok">✓</span> ${r.metrics.width}×${r.metrics.height} · layout ${r.metrics.layoutMs} ms${nw ? ` · <span style="color:var(--warn)">${nw} warning${nw > 1 ? 's' : ''}</span>` : ''} · engine v${version}`;
     } else {
       // errors: do NOT render the diagram at all — clear it and show a clear
@@ -269,19 +286,135 @@ document.getElementById('download-matrix').addEventListener('click', () => {
   download(format(lastMatrix), mime, 'diagram.flow.' + ext);
 });
 
-document.getElementById('zoom').addEventListener('click', e => {
-  const z = e.target.dataset.z;
-  if (!z) return;
-  zoom = z === '1' ? 1 : Math.min(4, Math.max(0.2, zoom * parseFloat(z)));
-  applyZoom();
-});
-function applyZoom() {
-  const svg = preview.querySelector('svg');
-  if (!svg || !svg.viewBox || !svg.viewBox.baseVal) return;
-  const vb = svg.viewBox.baseVal;
-  svg.style.width = (vb.width * zoom) + 'px';
-  svg.style.height = (vb.height * zoom) + 'px';
+// --- Zoom and pan -----------------------------------------------------------
+// The buttons step through a fixed ladder instead of multiplying by a factor:
+// with a multiplier, zooming in then out lands on 0.99975 rather than 1, and a
+// step that clamps at the top loses the levels above it on the way back down.
+// Ladder stops are exact, so any in/out sequence returns to where it started.
+const ZOOM_STOPS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+const ZOOM_MIN = ZOOM_STOPS[0];
+const ZOOM_MAX = ZOOM_STOPS[ZOOM_STOPS.length - 1];
+// Wheel deltas are in pixels; this turns one notch (~100px on most mice) into
+// roughly a 16% change, small enough that zooming feels continuous.
+const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+// Breathing room left around a fitted diagram, so it doesn't touch the edges.
+const FIT_PADDING_PX = 24;
+// Fit and wheel zoom land between stops; tolerate that when picking the next.
+const ZOOM_EPSILON = 1e-4;
+
+const clampZoom = z => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+
+/** The ladder stop just above (`direction` 1) or below (-1) the current zoom. */
+function nextZoomStop(direction) {
+  const stops = direction > 0 ? ZOOM_STOPS : ZOOM_STOPS.slice().reverse();
+  const isBeyondCurrent = stop => direction * (stop - zoom) > ZOOM_EPSILON;
+  return stops.find(isBeyondCurrent) ?? zoom;
 }
+
+/** The zoom level at which the whole diagram fits inside the preview pane. */
+function fitToPaneZoom() {
+  const box = svgViewBox();
+  if (!box) return zoom;
+  const width = preview.clientWidth - FIT_PADDING_PX;
+  const height = preview.clientHeight - FIT_PADDING_PX;
+  return clampZoom(Math.min(width / box.width, height / box.height));
+}
+
+function svgViewBox() {
+  const svg = preview.querySelector('svg');
+  return svg?.viewBox?.baseVal?.width ? svg.viewBox.baseVal : null;
+}
+
+/**
+ * Zoom to `next`, keeping the diagram point under `anchor` (a mouse event, or
+ * the centre of the pane when omitted) on the same pixel. Scaling without an
+ * anchor slides the diagram out from under wherever you were looking.
+ */
+function setZoom(next, anchor) {
+  const previous = zoom;
+  zoom = clampZoom(next);
+  if (zoom === previous) return;
+  const pane = preview.getBoundingClientRect();
+  const anchorX = anchor ? anchor.clientX - pane.left : preview.clientWidth / 2;
+  const anchorY = anchor ? anchor.clientY - pane.top : preview.clientHeight / 2;
+  const scrollLeft = preview.scrollLeft, scrollTop = preview.scrollTop;
+  const ratio = zoom / previous;
+  applyZoom();
+  // The diagram sits flush with the pane's top-left corner at every zoom level
+  // (`align-items:flex-start`, no justify-content), so the offset of a point
+  // inside the scrolled content is simply scroll + anchor, and scales with it.
+  preview.scrollLeft = (scrollLeft + anchorX) * ratio - anchorX;
+  preview.scrollTop = (scrollTop + anchorY) * ratio - anchorY;
+}
+
+function applyZoom() {
+  zoomLevel.textContent = Math.round(zoom * 100) + '%';
+  const box = svgViewBox();
+  if (!box) return;
+  const svg = preview.querySelector('svg');
+  svg.style.width = (box.width * zoom) + 'px';
+  svg.style.height = (box.height * zoom) + 'px';
+}
+
+const ZOOM_ACTIONS = {
+  in:    () => setZoom(nextZoomStop(1)),
+  out:   () => setZoom(nextZoomStop(-1)),
+  reset: () => setZoom(1),
+  fit:   () => { setZoom(fitToPaneZoom()); preview.scrollTo(0, 0); },
+};
+
+document.getElementById('zoom').addEventListener('click', e => {
+  ZOOM_ACTIONS[e.target.dataset.zoom]?.();
+});
+
+// ctrl/⌘ + wheel zooms at the pointer; a bare wheel still scrolls the pane.
+// Browsers report a trackpad pinch as a ctrl+wheel event, so pinch works too.
+preview.addEventListener('wheel', e => {
+  if (!e.ctrlKey && !e.metaKey) return;
+  e.preventDefault();
+  setZoom(zoom * Math.exp(-e.deltaY * WHEEL_ZOOM_SENSITIVITY), e);
+}, { passive: false });
+
+// Drag to pan. Touch is left to the browser, which already pans this scroll
+// container natively — handling it here as well would move it twice.
+let panStart = null;
+
+preview.addEventListener('pointerdown', e => {
+  if (e.button !== 0 || e.pointerType === 'touch' || !svgViewBox()) return;
+  e.preventDefault();   // otherwise the browser starts dragging the SVG itself
+  panStart = { x: e.clientX, y: e.clientY, left: preview.scrollLeft, top: preview.scrollTop };
+  preview.setPointerCapture(e.pointerId);
+  preview.classList.add('panning');
+});
+
+preview.addEventListener('pointermove', e => {
+  if (!panStart) return;
+  preview.scrollLeft = panStart.left - (e.clientX - panStart.x);
+  preview.scrollTop = panStart.top - (e.clientY - panStart.y);
+});
+
+function endPan(e) {
+  if (!panStart) return;
+  panStart = null;
+  preview.releasePointerCapture(e.pointerId);
+  preview.classList.remove('panning');
+}
+preview.addEventListener('pointerup', endPan);
+preview.addEventListener('pointercancel', endPan);
+
+const ZOOM_KEYS = { '+': 'in', '=': 'in', '-': 'out', '_': 'out', '0': 'reset' };
+
+const TYPING_TAGS = new Set(['TEXTAREA', 'INPUT', 'SELECT']);
+
+// Never while a field has focus, where these are just characters or list keys,
+// and never with a modifier held — ctrl/⌘ +/-/0 is the browser's own page zoom.
+document.addEventListener('keydown', e => {
+  if (TYPING_TAGS.has(e.target.tagName) || e.ctrlKey || e.metaKey || e.altKey) return;
+  const action = ZOOM_KEYS[e.key];
+  if (!action) return;
+  e.preventDefault();
+  ZOOM_ACTIONS[action]();
+});
 
 // load: shared link > logical starter
 const m = location.hash.match(/src=([^&]+)/);

--- a/playground/index.html
+++ b/playground/index.html
@@ -13,9 +13,6 @@
   header .dim { color:var(--dim); font-size:12px; }
   header select, header button { background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:5px 10px; font-size:12.5px; cursor:pointer; }
   header button:hover, header select:hover { border-color:var(--accent); }
-  /* The zoom controls live at the right end of the navbar, alongside the other
-     actions — in the preview's own footer they went unnoticed. Narrower than
-     the rest so the group reads as one control, not four more buttons. */
   #zoom { margin-left:auto; display:flex; gap:4px; align-items:center; }
   #zoom button { width:28px; padding:5px 0; border-radius:4px; }
   #zoom-level { width:54px; font-variant-numeric:tabular-nums; }
@@ -34,8 +31,7 @@
   #preview { flex:1; overflow:auto; background:#ffffff; display:flex; align-items:flex-start; position:relative; cursor:grab; }
   #preview.panning { cursor:grabbing; }
   #preview.error { cursor:default; }
-  /* flex:none — a zoomed-in diagram is wider than the pane, and the default
-     flex-shrink would squeeze it back to fit instead of letting it overflow. */
+  /* flex:none, or a zoomed-in diagram gets shrunk back to the pane width. */
   #preview svg { max-width:none; flex:none; }
   #preview.stale svg { opacity:.45; transition:opacity .1s; }
   #preview.error { background:#fff5f5; }
@@ -170,10 +166,8 @@ const b64decode = s => new TextDecoder().decode(Uint8Array.from(atob(s), c => c.
 // switches to a clear error state and points at the error list below.
 let running = false, pending = false;
 
-// A diagram that arrived whole — pasted in, picked from the templates menu, or
-// carried by a shared link — is one nobody has framed yet, so the next render
-// fits it to the pane. Ordinary edits leave the reader's own zoom and pan be.
-// The first render is a load, hence the initial `true`.
+// A diagram that arrived whole — pasted, templated, or carried by a shared
+// link — is one nobody has framed yet. Ordinary edits keep the reader's framing.
 let fitOnNextRender = true;
 
 function schedule() {
@@ -199,16 +193,14 @@ async function run() {
     if (r.svg) {
       lastSvg = r.svg;
       preview.classList.remove('error');
-      // Replacing the SVG resets the pane's scroll, which would throw away the
-      // reader's pan on every keystroke. Put it back after the new one is sized.
+      // Replacing the SVG resets the pane's scroll — restore it once resized.
       const { scrollLeft, scrollTop } = preview;
       preview.innerHTML = r.svg;
       // match the preview backdrop to the theme's canvas colour
       const bg = (r.svg.match(/<rect width="\d+" height="\d+" fill="([^"]+)"\/>/) || [])[1];
       if (bg) preview.style.background = bg;
       applyZoom();
-      // Cleared only here, so a paste that does not compile is still fitted
-      // once the errors are fixed and it finally renders.
+      // Cleared only here, so a paste that does not compile is fitted once fixed.
       if (fitOnNextRender) {
         fitOnNextRender = false;
         fitToPane();
@@ -240,11 +232,8 @@ async function run() {
 
 editor.addEventListener('input', schedule);
 
-// Fit after a paste that replaces the whole source — dropping a diagram in
-// wholesale. `paste` fires before the value changes, so the selection here is
-// still the range about to be overwritten; covering the whole value (an empty
-// editor included) means the pasted text becomes the entire diagram. Pasting a
-// fragment into an existing diagram is an ordinary edit and keeps the framing.
+// `paste` fires before the value changes, so the selection is still the range
+// about to be overwritten: covering all of it means the paste is the diagram.
 editor.addEventListener('paste', () => {
   const replacesWholeSource =
     editor.selectionStart === 0 && editor.selectionEnd === editor.value.length;
@@ -312,39 +301,28 @@ document.getElementById('download-matrix').addEventListener('click', () => {
 });
 
 // --- Zoom and pan -----------------------------------------------------------
-// The buttons step through a fixed ladder instead of multiplying by a factor:
-// with a multiplier, zooming in then out lands on 0.99975 rather than 1, and a
-// step that clamps at the top loses the levels above it on the way back down.
-// Ladder stops are exact, so any in/out sequence returns to where it started.
-// The floor has to be low enough to frame the widest views cairn is built for:
-// examples/large-fr.cairn renders 3995px wide and needs about 20% to fit a
-// half-window pane, so a floor above that would leave "fit" still overflowing.
+// A ladder of exact stops, not a multiplier: `zoom *= 1.333` then `*= 0.75`
+// lands on 0.99975, never back on 100%. The floor is low because
+// examples/large-fr.cairn is 3995px wide and needs ~20% to fit a half window.
 const ZOOM_STOPS = [0.1, 0.15, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
 const ZOOM_MIN = ZOOM_STOPS[0];
 const ZOOM_MAX = ZOOM_STOPS[ZOOM_STOPS.length - 1];
-// Wheel deltas are in pixels; this turns one notch (~100px on most mice) into
-// roughly a 16% change, small enough that zooming feels continuous.
+// One wheel notch (~100px) is about a 16% change.
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
-// Breathing room left around a fitted diagram, so it doesn't touch the edges.
 const FIT_PADDING_PX = 24;
-// Fit and wheel zoom land between stops; tolerate that when picking the next.
+// Fit and wheel zoom land between stops, so "beyond current" needs slack.
 const ZOOM_EPSILON = 1e-4;
 
 const clampZoom = z => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
 
-/** The ladder stop just above (`direction` 1) or below (-1) the current zoom. */
 function nextZoomStop(direction) {
   const stops = direction > 0 ? ZOOM_STOPS : ZOOM_STOPS.slice().reverse();
   const isBeyondCurrent = stop => direction * (stop - zoom) > ZOOM_EPSILON;
   return stops.find(isBeyondCurrent) ?? zoom;
 }
 
-/**
- * The zoom level at which the whole diagram fits inside the preview pane.
- * Shrinks only — magnifying a three-box starter to fill the pane is not what
- * "fit" means here, and this also runs unattended on load, where jumping a
- * small diagram to 400% would be startling rather than helpful.
- */
+/** Shrinks only: this runs unattended on load, where blowing a starter
+    template up to 400% would startle rather than help. */
 function paneFitZoom() {
   const box = svgViewBox();
   if (!box) return zoom;
@@ -353,7 +331,6 @@ function paneFitZoom() {
   return clampZoom(Math.min(width / box.width, height / box.height, 1));
 }
 
-/** Frame the whole diagram: fitted, and scrolled back to its top-left corner. */
 function fitToPane() {
   setZoom(paneFitZoom());
   preview.scrollTo(0, 0);
@@ -364,11 +341,8 @@ function svgViewBox() {
   return svg?.viewBox?.baseVal?.width ? svg.viewBox.baseVal : null;
 }
 
-/**
- * Zoom to `next`, keeping the diagram point under `anchor` (a mouse event, or
- * the centre of the pane when omitted) on the same pixel. Scaling without an
- * anchor slides the diagram out from under wherever you were looking.
- */
+/** Zooms with the point under `anchor` (a mouse event, else the pane centre)
+    pinned to the same pixel, so the diagram does not slide out from under it. */
 function setZoom(next, anchor) {
   const previous = zoom;
   zoom = clampZoom(next);
@@ -379,9 +353,8 @@ function setZoom(next, anchor) {
   const scrollLeft = preview.scrollLeft, scrollTop = preview.scrollTop;
   const ratio = zoom / previous;
   applyZoom();
-  // The diagram sits flush with the pane's top-left corner at every zoom level
-  // (`align-items:flex-start`, no justify-content), so the offset of a point
-  // inside the scrolled content is simply scroll + anchor, and scales with it.
+  // Valid only while the SVG sits flush with the pane's top-left corner: any
+  // centring in #preview's flex rules puts an offset between them.
   preview.scrollLeft = (scrollLeft + anchorX) * ratio - anchorX;
   preview.scrollTop = (scrollTop + anchorY) * ratio - anchorY;
 }
@@ -406,16 +379,15 @@ document.getElementById('zoom').addEventListener('click', e => {
   ZOOM_ACTIONS[e.target.dataset.zoom]?.();
 });
 
-// ctrl/⌘ + wheel zooms at the pointer; a bare wheel still scrolls the pane.
-// Browsers report a trackpad pinch as a ctrl+wheel event, so pinch works too.
+// A trackpad pinch reaches the page as a ctrl+wheel event, so this covers both.
 preview.addEventListener('wheel', e => {
   if (!e.ctrlKey && !e.metaKey) return;
   e.preventDefault();
   setZoom(zoom * Math.exp(-e.deltaY * WHEEL_ZOOM_SENSITIVITY), e);
 }, { passive: false });
 
-// Drag to pan. Touch is left to the browser, which already pans this scroll
-// container natively — handling it here as well would move it twice.
+// Touch is left to the browser, which already pans this scroll container —
+// handling it here too would move it twice.
 let panStart = null;
 
 preview.addEventListener('pointerdown', e => {
@@ -445,8 +417,7 @@ const ZOOM_KEYS = { '+': 'in', '=': 'in', '-': 'out', '_': 'out', '0': 'reset' }
 
 const TYPING_TAGS = new Set(['TEXTAREA', 'INPUT', 'SELECT']);
 
-// Never while a field has focus, where these are just characters or list keys,
-// and never with a modifier held — ctrl/⌘ +/-/0 is the browser's own page zoom.
+// Modifier held means the browser's own page zoom (ctrl/⌘ +/-/0), not ours.
 document.addEventListener('keydown', e => {
   if (TYPING_TAGS.has(e.target.tagName) || e.ctrlKey || e.metaKey || e.altKey) return;
   const action = ZOOM_KEYS[e.key];

--- a/playground/index.html
+++ b/playground/index.html
@@ -13,6 +13,13 @@
   header .dim { color:var(--dim); font-size:12px; }
   header select, header button { background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:5px 10px; font-size:12.5px; cursor:pointer; }
   header button:hover, header select:hover { border-color:var(--accent); }
+  /* The zoom controls live at the right end of the navbar, alongside the other
+     actions — in the preview's own footer they went unnoticed. Narrower than
+     the rest so the group reads as one control, not four more buttons. */
+  #zoom { margin-left:auto; display:flex; gap:4px; align-items:center; }
+  #zoom button { width:28px; padding:5px 0; border-radius:4px; }
+  #zoom-level { width:54px; font-variant-numeric:tabular-nums; }
+  #zoom-fit { width:auto; padding:5px 10px; }
   main { flex:1; display:flex; min-height:0; }
   .left { width:44%; min-width:320px; display:flex; flex-direction:column; border-right:1px solid var(--border); }
   #editor { flex:1; resize:none; border:0; outline:0; padding:12px 14px; background:var(--bg); color:var(--text); font:13px/1.55 ui-monospace,Menlo,Consolas,monospace; white-space:pre; tab-size:2; }
@@ -38,11 +45,6 @@
   .err-panel .err-p { margin-top:8px; font-size:13.5px; line-height:1.6; color:#8a5a5a; }
   #status { padding:6px 14px; background:var(--panel); border-top:1px solid var(--border); font-size:12px; color:var(--dim); display:flex; gap:16px; align-items:center; }
   #status .ok { color:var(--ok); } #status .err { color:var(--err); }
-  #zoom { margin-left:auto; display:flex; gap:6px; align-items:center; }
-  #zoom button { background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:4px; width:26px; cursor:pointer; }
-  #zoom button:hover { border-color:var(--accent); }
-  #zoom-level { width:52px; font-variant-numeric:tabular-nums; }
-  #zoom-fit { width:auto; padding:0 8px; }
   .note { color:var(--dim); font-size:12px; }
 </style>
 </head>
@@ -68,6 +70,12 @@
   </select>
   <button id="download-matrix" title="The flows of this diagram as a table — the matrice des flux techniques">Download matrix</button>
   <span class="note" id="note"></span>
+  <span id="zoom">
+    <button data-zoom="out" title="Zoom out (−)">−</button>
+    <button data-zoom="reset" id="zoom-level" title="Reset to 100% (0)">100%</button>
+    <button data-zoom="in" title="Zoom in (+)">+</button>
+    <button data-zoom="fit" id="zoom-fit" title="Fit the whole diagram in the pane">fit</button>
+  </span>
   <!-- The engine bundle inlines elkjs (EPL-2.0) and the Simple Icons artwork,
        so serving this page distributes them: the notices have to be reachable
        from it. build-playground.sh copies THIRD-PARTY-NOTICES.md in beside the
@@ -82,14 +90,7 @@
   </div>
   <div class="right">
     <div id="preview" title="Drag to pan · ctrl/⌘ + wheel to zoom"></div>
-    <div id="status"><span id="stat">loading engine…</span>
-      <span id="zoom">
-        <button data-zoom="out" title="Zoom out (−)">−</button>
-        <button data-zoom="reset" id="zoom-level" title="Reset to 100% (0)">100%</button>
-        <button data-zoom="in" title="Zoom in (+)">+</button>
-        <button data-zoom="fit" id="zoom-fit" title="Fit the whole diagram in the pane">fit</button>
-      </span>
-    </div>
+    <div id="status"><span id="stat">loading engine…</span></div>
   </div>
 </main>
 
@@ -169,6 +170,12 @@ const b64decode = s => new TextDecoder().decode(Uint8Array.from(atob(s), c => c.
 // switches to a clear error state and points at the error list below.
 let running = false, pending = false;
 
+// A diagram that arrived whole — pasted in, picked from the templates menu, or
+// carried by a shared link — is one nobody has framed yet, so the next render
+// fits it to the pane. Ordinary edits leave the reader's own zoom and pan be.
+// The first render is a load, hence the initial `true`.
+let fitOnNextRender = true;
+
 function schedule() {
   preview.classList.add('stale');
   clearTimeout(schedule._t);
@@ -200,7 +207,14 @@ async function run() {
       const bg = (r.svg.match(/<rect width="\d+" height="\d+" fill="([^"]+)"\/>/) || [])[1];
       if (bg) preview.style.background = bg;
       applyZoom();
-      preview.scrollTo(scrollLeft, scrollTop);
+      // Cleared only here, so a paste that does not compile is still fitted
+      // once the errors are fixed and it finally renders.
+      if (fitOnNextRender) {
+        fitOnNextRender = false;
+        fitToPane();
+      } else {
+        preview.scrollTo(scrollLeft, scrollTop);
+      }
       stat.innerHTML = `<span class="ok">✓</span> ${r.metrics.width}×${r.metrics.height} · layout ${r.metrics.layoutMs} ms${nw ? ` · <span style="color:var(--warn)">${nw} warning${nw > 1 ? 's' : ''}</span>` : ''} · engine v${version}`;
     } else {
       // errors: do NOT render the diagram at all — clear it and show a clear
@@ -226,6 +240,17 @@ async function run() {
 
 editor.addEventListener('input', schedule);
 
+// Fit after a paste that replaces the whole source — dropping a diagram in
+// wholesale. `paste` fires before the value changes, so the selection here is
+// still the range about to be overwritten; covering the whole value (an empty
+// editor included) means the pasted text becomes the entire diagram. Pasting a
+// fragment into an existing diagram is an ordinary edit and keeps the framing.
+editor.addEventListener('paste', () => {
+  const replacesWholeSource =
+    editor.selectionStart === 0 && editor.selectionEnd === editor.value.length;
+  if (replacesWholeSource) fitOnNextRender = true;
+});
+
 diagsEl.addEventListener('click', e => {
   const line = e.target.closest('.diag')?.dataset.line;
   if (!line) return;
@@ -236,7 +261,7 @@ diagsEl.addEventListener('click', e => {
 // --- Templates --------------------------------------------------------------
 document.getElementById('templates').addEventListener('change', e => {
   const t = TEMPLATES[e.target.value];
-  if (t) { editor.value = t; run(); }
+  if (t) { editor.value = t; fitOnNextRender = true; run(); }
   e.target.value = '';
 });
 
@@ -291,7 +316,10 @@ document.getElementById('download-matrix').addEventListener('click', () => {
 // with a multiplier, zooming in then out lands on 0.99975 rather than 1, and a
 // step that clamps at the top loses the levels above it on the way back down.
 // Ladder stops are exact, so any in/out sequence returns to where it started.
-const ZOOM_STOPS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+// The floor has to be low enough to frame the widest views cairn is built for:
+// examples/large-fr.cairn renders 3995px wide and needs about 20% to fit a
+// half-window pane, so a floor above that would leave "fit" still overflowing.
+const ZOOM_STOPS = [0.1, 0.15, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
 const ZOOM_MIN = ZOOM_STOPS[0];
 const ZOOM_MAX = ZOOM_STOPS[ZOOM_STOPS.length - 1];
 // Wheel deltas are in pixels; this turns one notch (~100px on most mice) into
@@ -311,13 +339,24 @@ function nextZoomStop(direction) {
   return stops.find(isBeyondCurrent) ?? zoom;
 }
 
-/** The zoom level at which the whole diagram fits inside the preview pane. */
-function fitToPaneZoom() {
+/**
+ * The zoom level at which the whole diagram fits inside the preview pane.
+ * Shrinks only — magnifying a three-box starter to fill the pane is not what
+ * "fit" means here, and this also runs unattended on load, where jumping a
+ * small diagram to 400% would be startling rather than helpful.
+ */
+function paneFitZoom() {
   const box = svgViewBox();
   if (!box) return zoom;
   const width = preview.clientWidth - FIT_PADDING_PX;
   const height = preview.clientHeight - FIT_PADDING_PX;
-  return clampZoom(Math.min(width / box.width, height / box.height));
+  return clampZoom(Math.min(width / box.width, height / box.height, 1));
+}
+
+/** Frame the whole diagram: fitted, and scrolled back to its top-left corner. */
+function fitToPane() {
+  setZoom(paneFitZoom());
+  preview.scrollTo(0, 0);
 }
 
 function svgViewBox() {
@@ -360,7 +399,7 @@ const ZOOM_ACTIONS = {
   in:    () => setZoom(nextZoomStop(1)),
   out:   () => setZoom(nextZoomStop(-1)),
   reset: () => setZoom(1),
-  fit:   () => { setZoom(fitToPaneZoom()); preview.scrollTo(0, 0); },
+  fit:   fitToPane,
 };
 
 document.getElementById('zoom').addEventListener('click', e => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added zoom controls for zooming in, zooming out, resetting, and fitting the diagram preview.
  - Added Ctrl/⌘ + mouse-wheel zooming centered on the cursor.
  - Added drag-to-pan support and keyboard shortcuts: `+`, `-`, and `0`.
  - The diagram now automatically fits the preview after initial rendering, whole-source pastes, and template loads.
  - Preview scroll position is preserved when the diagram re-renders.

- **Changes**
  - Removed the previous status-bar zoom controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->